### PR TITLE
Step 917 auto provision

### DIFF
--- a/sample-apps-fastlane-test.xcodeproj/project.pbxproj
+++ b/sample-apps-fastlane-test.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		138CDF5526661E14009CA017 /* sample_apps_fastlane_testUITests2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138CDF5426661E14009CA017 /* sample_apps_fastlane_testUITests2.swift */; };
 		1B68A22A223FD202002EC453 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B68A229223FD202002EC453 /* AppDelegate.swift */; };
 		1B68A22C223FD202002EC453 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B68A22B223FD202002EC453 /* ViewController.swift */; };
 		1B68A22F223FD202002EC453 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1B68A22D223FD202002EC453 /* Main.storyboard */; };
@@ -17,6 +18,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		138CDF5726661E14009CA017 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1B68A21E223FD202002EC453 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1B68A225223FD202002EC453;
+			remoteInfo = "sample-apps-fastlane-test";
+		};
 		1B68A23B223FD203002EC453 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1B68A21E223FD202002EC453 /* Project object */;
@@ -34,6 +42,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		138CDF5226661E14009CA017 /* sample-apps-fastlane-testUITests2.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "sample-apps-fastlane-testUITests2.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		138CDF5426661E14009CA017 /* sample_apps_fastlane_testUITests2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sample_apps_fastlane_testUITests2.swift; sourceTree = "<group>"; };
+		138CDF5626661E14009CA017 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1B68A226223FD202002EC453 /* sample-apps-fastlane-test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "sample-apps-fastlane-test.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B68A229223FD202002EC453 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1B68A22B223FD202002EC453 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -50,6 +61,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		138CDF4F26661E14009CA017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1B68A223223FD202002EC453 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -74,12 +92,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		138CDF5326661E14009CA017 /* sample-apps-fastlane-testUITests2 */ = {
+			isa = PBXGroup;
+			children = (
+				138CDF5426661E14009CA017 /* sample_apps_fastlane_testUITests2.swift */,
+				138CDF5626661E14009CA017 /* Info.plist */,
+			);
+			path = "sample-apps-fastlane-testUITests2";
+			sourceTree = "<group>";
+		};
 		1B68A21D223FD202002EC453 = {
 			isa = PBXGroup;
 			children = (
 				1B68A228223FD202002EC453 /* sample-apps-fastlane-test */,
 				1B68A23D223FD203002EC453 /* sample-apps-fastlane-testTests */,
 				1B68A248223FD203002EC453 /* sample-apps-fastlane-testUITests */,
+				138CDF5326661E14009CA017 /* sample-apps-fastlane-testUITests2 */,
 				1B68A227223FD202002EC453 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,6 +118,7 @@
 				1B68A226223FD202002EC453 /* sample-apps-fastlane-test.app */,
 				1B68A23A223FD203002EC453 /* sample-apps-fastlane-testTests.xctest */,
 				1B68A245223FD203002EC453 /* sample-apps-fastlane-testUITests.xctest */,
+				138CDF5226661E14009CA017 /* sample-apps-fastlane-testUITests2.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -128,6 +157,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		138CDF5126661E14009CA017 /* sample-apps-fastlane-testUITests2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 138CDF5B26661E14009CA017 /* Build configuration list for PBXNativeTarget "sample-apps-fastlane-testUITests2" */;
+			buildPhases = (
+				138CDF4E26661E14009CA017 /* Sources */,
+				138CDF4F26661E14009CA017 /* Frameworks */,
+				138CDF5026661E14009CA017 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				138CDF5826661E14009CA017 /* PBXTargetDependency */,
+			);
+			name = "sample-apps-fastlane-testUITests2";
+			productName = "sample-apps-fastlane-testUITests2";
+			productReference = 138CDF5226661E14009CA017 /* sample-apps-fastlane-testUITests2.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		1B68A225223FD202002EC453 /* sample-apps-fastlane-test */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1B68A24E223FD203002EC453 /* Build configuration list for PBXNativeTarget "sample-apps-fastlane-test" */;
@@ -187,10 +234,14 @@
 		1B68A21E223FD202002EC453 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1010;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = Bitrise;
 				TargetAttributes = {
+					138CDF5126661E14009CA017 = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = 1B68A225223FD202002EC453;
+					};
 					1B68A225223FD202002EC453 = {
 						CreatedOnToolsVersion = 10.1;
 					};
@@ -220,11 +271,19 @@
 				1B68A225223FD202002EC453 /* sample-apps-fastlane-test */,
 				1B68A239223FD203002EC453 /* sample-apps-fastlane-testTests */,
 				1B68A244223FD203002EC453 /* sample-apps-fastlane-testUITests */,
+				138CDF5126661E14009CA017 /* sample-apps-fastlane-testUITests2 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		138CDF5026661E14009CA017 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1B68A224223FD202002EC453 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -252,6 +311,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		138CDF4E26661E14009CA017 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				138CDF5526661E14009CA017 /* sample_apps_fastlane_testUITests2.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1B68A222223FD202002EC453 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -280,6 +347,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		138CDF5826661E14009CA017 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1B68A225223FD202002EC453 /* sample-apps-fastlane-test */;
+			targetProxy = 138CDF5726661E14009CA017 /* PBXContainerItemProxy */;
+		};
 		1B68A23C223FD203002EC453 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 1B68A225223FD202002EC453 /* sample-apps-fastlane-test */;
@@ -312,6 +384,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		138CDF5926661E14009CA017 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				INFOPLIST_FILE = "sample-apps-fastlane-testUITests2/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.sample-apps-fastlane-testUITests2";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "sample-apps-fastlane-test";
+			};
+			name = Debug;
+		};
+		138CDF5A26661E14009CA017 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				INFOPLIST_FILE = "sample-apps-fastlane-testUITests2/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.sample-apps-fastlane-testUITests2";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "sample-apps-fastlane-test";
+			};
+			name = Release;
+		};
 		1B68A24C223FD203002EC453 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -563,6 +677,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		138CDF5B26661E14009CA017 /* Build configuration list for PBXNativeTarget "sample-apps-fastlane-testUITests2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				138CDF5926661E14009CA017 /* Debug */,
+				138CDF5A26661E14009CA017 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		1B68A221223FD202002EC453 /* Build configuration list for PBXProject "sample-apps-fastlane-test" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/sample-apps-fastlane-test.xcodeproj/project.pbxproj
+++ b/sample-apps-fastlane-test.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.sample-apps-fastlane-testTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sample-apps-fastlane-test.app/sample-apps-fastlane-test";
@@ -510,6 +511,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.sample-apps-fastlane-testTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/sample-apps-fastlane-test.app/sample-apps-fastlane-test";
@@ -530,6 +532,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.sample-apps-fastlane-testUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "sample-apps-fastlane-test";
@@ -550,6 +553,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.sample-apps-fastlane-testUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "sample-apps-fastlane-test";

--- a/sample-apps-fastlane-test.xcodeproj/project.pbxproj
+++ b/sample-apps-fastlane-test.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.sample-apps-fastlane-testUITests2";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "sample-apps-fastlane-test";
@@ -420,6 +421,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.bitrise.sample-apps-fastlane-testUITests2";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "sample-apps-fastlane-test";

--- a/sample-apps-fastlane-test.xcodeproj/xcshareddata/xcschemes/sample-apps-fastlane-test.xcscheme
+++ b/sample-apps-fastlane-test.xcodeproj/xcshareddata/xcschemes/sample-apps-fastlane-test.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1B68A225223FD202002EC453"
+            BuildableName = "sample-apps-fastlane-test.app"
+            BlueprintName = "sample-apps-fastlane-test"
+            ReferencedContainer = "container:sample-apps-fastlane-test.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,18 +57,17 @@
                ReferencedContainer = "container:sample-apps-fastlane-test.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "138CDF5126661E14009CA017"
+               BuildableName = "sample-apps-fastlane-testUITests2.xctest"
+               BlueprintName = "sample-apps-fastlane-testUITests2"
+               ReferencedContainer = "container:sample-apps-fastlane-test.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1B68A225223FD202002EC453"
-            BuildableName = "sample-apps-fastlane-test.app"
-            BlueprintName = "sample-apps-fastlane-test"
-            ReferencedContainer = "container:sample-apps-fastlane-test.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -81,8 +89,6 @@
             ReferencedContainer = "container:sample-apps-fastlane-test.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/sample-apps-fastlane-testUITests2/Info.plist
+++ b/sample-apps-fastlane-testUITests2/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/sample-apps-fastlane-testUITests2/sample_apps_fastlane_testUITests2.swift
+++ b/sample-apps-fastlane-testUITests2/sample_apps_fastlane_testUITests2.swift
@@ -1,0 +1,43 @@
+//
+//  sample_apps_fastlane_testUITests2.swift
+//  sample-apps-fastlane-testUITests2
+//
+//  Created by Krisztian Godrei on 2021. 06. 01..
+//  Copyright © 2021. Bitrise. All rights reserved.
+//
+
+import XCTest
+
+class sample_apps_fastlane_testUITests2: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds one more UITest target (`sample-apps-fastlane-testUITests2`) to the project and turns off Catalyst support for all UITest targets.
This change will be used for testing the [iOS Auto Provision step's UITest target Signing support](https://github.com/bitrise-steplib/steps-ios-auto-provision-appstoreconnect/pull/51).